### PR TITLE
Improve README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,71 @@
 # ZeroExcuses-NLP
 
+ZeroExcuses-NLP is a small project for emotion classification using text embeddings and a simple machine learning model. It provides scripts to train a classifier on the Hugging Face *emotion* dataset and exposes a FastAPI API for inference.
+
+## Project structure
+
+```
 #zeroexcuses-nlp/
-#│
-#├── app/                  # Código da API
-#│   ├── main.py           # FastAPI app
-#│   └── model.py          # Carrega o modelo e faz predição
-#│
-#├── data/                 # Dados brutos e processados
-#│   ├── raw/              # CSVs ou datasets baixados
-#│   └── processed/        # Pronto pra treinar
-#│
-#├── models/               # Modelos salvos (.pkl ou .joblib)
-#│   └── classifier.joblib
-#│
-#├── notebooks/            # Testes e protótipos (Jupyter ou colab)
-#│   └── exploracao.ipynb
-#│
-#├── src/                  # Código de treino e pré-processamento
-#│   ├── preprocess.py     # Limpeza de texto
-#│   └── train.py          # Treinamento do modelo
-#│
-#├── requirements.txt      # Dependências do projeto
-#├── README.md             # Descrição do projeto
-#└── .gitignore            # Ignorar modelos grandes, pastas etc.
-# force redeploy
+│
+├── app/                  # API code
+│   ├── main.py           # FastAPI app
+│   └── model.py          # Loads the model and performs prediction
+│
+├── data/                 # Raw and processed data
+│   ├── raw/              # CSVs or downloaded datasets
+│   └── processed/        # Ready for training
+│
+├── models/               # Saved models (.pkl or .joblib)
+│   └── classifier.joblib
+│
+├── notebooks/            # Experiments and prototypes
+│   └── exploracao.ipynb
+│
+├── src/                  # Training and preprocessing code
+│   ├── preprocess.py     # Text cleaning
+│   └── train.py          # Model training
+│
+├── requirements.txt      # Project dependencies
+├── README.md             # Project description
+└── .gitignore            # Ignore large models, folders, etc.
+```
+
+## Setup
+
+Create a virtual environment and install the dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Training the model
+
+Run the training script to download the dataset, generate embeddings and fit the classifier:
+
+```bash
+python src/train.py
+```
+
+The trained model will be saved under `models/`.
+
+## Running the API
+
+Start the FastAPI server with Uvicorn:
+
+```bash
+uvicorn app.main:app
+```
+
+The interactive documentation will be available at `http://localhost:8000/docs`.
+
+## `/predict` endpoint example
+
+Send a POST request with JSON containing the text to classify:
+
+```bash
+curl -X POST http://localhost:8000/predict -H 'Content-Type: application/json' -d '{"text": "I am feeling great today!"}'
+```
+
+The API returns the predicted emotion and the probabilities for each class.


### PR DESCRIPTION
## Summary
- document project overview and layout
- add setup, training, and API usage instructions
- provide example request to `/predict`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684504805888832693ef32448a77613c